### PR TITLE
FCS-67 fix: fixed an issue on android where measurement would remain enabled

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,6 @@ apply plugin: 'com.android.library'
 android {
     namespace "com.fibricheck.camera_sdk"
     compileSdkVersion 34
-    ndkVersion "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    namespace "com.fibricheck.camera_sdk"
+    compileSdkVersion 34
+    ndkVersion "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
@@ -32,7 +34,7 @@ android {
 
     defaultConfig {
         minSdkVersion 20
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 2
         versionName "1.0.1"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.6.1'
     }
 }
 
@@ -42,7 +42,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'com.github.fibricheck:android-camera-sdk:v1.0.1'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-v13:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-v13:28.0.0'
     implementation 'com.google.code.gson:gson:+'
 }

--- a/android/src/main/java/com/fibricheck/camera_sdk/FlutterFibriCheckView.java
+++ b/android/src/main/java/com/fibricheck/camera_sdk/FlutterFibriCheckView.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
@@ -72,10 +74,9 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
 
     private int xValue = 0;
 
-    @NonNull final private GraphView graphView;
-    @NonNull final private View view;
-    
-    private FibriChecker fibriChecker;
+    @NonNull private final GraphView graphView;
+    @NonNull private final LinearLayout linearLayout;
+    @NonNull private final FibriChecker fibriChecker;
 
     FlutterFibriCheckView(@NonNull Context context, BinaryMessenger messenger, int id, @Nullable Map<String, Object> creationParams) {
         this.context = context;
@@ -91,12 +92,9 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
         eventChannel.setStreamHandler(flutterFibriListener);
 
         graphView = createGraphView(context);
-        view = createView();
+        linearLayout = createView();
+        fibriChecker = createFibriChecker();
 
-        init();
-    }
-
-    private void init() {
         setupSeries();
     }
 
@@ -128,15 +126,20 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
         linearLayout.setOrientation(LinearLayout.HORIZONTAL);
         linearLayout.addView(graphView);
 
-        fibriChecker = new FibriChecker.FibriBuilder(context, linearLayout).build();
-        fibriChecker.setFibriListener(flutterFibriListener);
-
         return linearLayout;
     }
 
+    private FibriChecker createFibriChecker() {
+        FibriChecker newFibriChecker = new FibriChecker.FibriBuilder(context, linearLayout).build();
+        newFibriChecker.setFibriListener(flutterFibriListener);
+
+        return  newFibriChecker;
+    }
+
+    @NonNull
     @Override
     public View getView() {
-        return view;
+        return linearLayout;
     }
 
     @Override
@@ -145,7 +148,6 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
     }
 
     //region Props Setters
-
     public void setDrawGraph(boolean drawGraph) {
         drawGraphPoints = drawGraph;
     }
@@ -317,21 +319,19 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
     //region Graphs
     private GraphView createGraphView(Context context) {
         final GraphView newGraphView = new GraphView(context);
-        invalidateGraphView(newGraphView, context);
-        newGraphView.addSeries(series);
+        setupGraphView(newGraphView);
 
         return newGraphView;
     }
 
-    private void invalidateGraphView(GraphView graphView, Context context) {
+    private void setupGraphView(GraphView graphView) {
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
-        graphView.setBackgroundColor(Color.TRANSPARENT);
         params.gravity = Gravity.CENTER_HORIZONTAL;
-        graphView.setLayoutParams(params);
-        setViewPortOptions(graphView);
-    }
 
-    private void setViewPortOptions(GraphView graphView) {
+        graphView.setBackgroundColor(Color.TRANSPARENT);
+        graphView.setLayoutParams(params);
+        graphView.addSeries(series);
+
         Viewport viewport = graphView.getViewport();
         viewport.setScalable(false);
         viewport.setScrollable(false);
@@ -343,27 +343,30 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
 
     private int getScreenWidth(Context context) {
         Activity activity = Utils.getActivity(context);
-
-        if (activity == null){
+        if (activity == null) {
             return Resources.getSystem().getDisplayMetrics().widthPixels;
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            WindowMetrics windowMetrics = activity.getWindowManager().getCurrentWindowMetrics();
-            Insets insets = windowMetrics.getWindowInsets()
-                    .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars());
-            return windowMetrics.getBounds().width() - insets.left - insets.right;
+            return getScreenWidthAboveAndroidR(activity);
         } else {
             return getScreenWidthBelowAndroidR(activity);
         }
     }
 
     @TargetApi(Build.VERSION_CODES.Q)
-    @SuppressWarnings("deprecation")
     private int getScreenWidthBelowAndroidR(@NonNull Activity activity) {
         DisplayMetrics displayMetrics = new DisplayMetrics();
         activity.getWindowManager().getDefaultDisplay().getMetrics(displayMetrics);
         return displayMetrics.widthPixels;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.R)
+    private int getScreenWidthAboveAndroidR(@NonNull Activity activity) {
+        WindowMetrics windowMetrics = activity.getWindowManager().getCurrentWindowMetrics();
+        Insets insets = windowMetrics.getWindowInsets()
+                .getInsetsIgnoringVisibility(WindowInsets.Type.systemBars());
+        return windowMetrics.getBounds().width() - insets.left - insets.right;
     }
 
     private void addGraphData(double value) {
@@ -373,6 +376,7 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
 
     private void calculateYaxisBoundaries(double value) {
         addValueToSR(value);
+
         graphView.getViewport().setMaxY(Collections.max(valueSR) + 0.2);
         graphView.getViewport().setMinY(Collections.min(valueSR) - 0.2);
     }

--- a/android/src/main/java/com/fibricheck/camera_sdk/FlutterFibriCheckView.java
+++ b/android/src/main/java/com/fibricheck/camera_sdk/FlutterFibriCheckView.java
@@ -3,13 +3,11 @@ package com.fibricheck.camera_sdk;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Insets;
 import android.os.Build;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,11 +20,11 @@ import com.jjoe64.graphview.Viewport;
 import com.jjoe64.graphview.series.DataPoint;
 import com.jjoe64.graphview.series.LineGraphSeries;
 import com.qompium.fibricheck.camerasdk.FibriChecker;
-import com.fibricheck.camera_sdk.Utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -63,50 +61,87 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
 
     private final Context context;
 
-    @NonNull
-    private final MethodChannel methodChannel;
-    private final EventChannel eventChannel;
-    private final FlutterFibriListener flutterFibriListener;
+    @NonNull private final MethodChannel methodChannel;
+    @NonNull private final EventChannel eventChannel;
+    @NonNull private final FlutterFibriListener flutterFibriListener;
 
     private boolean drawGraphPoints = false;
 
-    private LineGraphSeries<DataPoint> series;
-
-    private ArrayList<Double> valueSR;
+    @NonNull private final LineGraphSeries<DataPoint> series = new LineGraphSeries<>();
+    @NonNull private final ArrayList<Double> valueSR = new ArrayList<>();
 
     private int xValue = 0;
 
-    private GraphView graphView;
-
-    private LinearLayout linearLayout;
-
+    @NonNull final private GraphView graphView;
+    @NonNull final private View view;
+    
     private FibriChecker fibriChecker;
 
     FlutterFibriCheckView(@NonNull Context context, BinaryMessenger messenger, int id, @Nullable Map<String, Object> creationParams) {
         this.context = context;
 
-        String channelId = creationParams == null ? "" : (String) creationParams.get("channelId");
+        String channelId = creationParams == null ? "" : (String) Objects.requireNonNullElse(creationParams.get("channelId"), "");
         String channelName = "com.fibricheck.camera_sdk/flutterFibriCheckView_" + channelId;
 
+        // Init final member variables
+        flutterFibriListener = new FlutterFibriListener(this);
         methodChannel = new MethodChannel(messenger, channelName + "_method");
         methodChannel.setMethodCallHandler(this);
-
-        flutterFibriListener = new FlutterFibriListener(this);
-
         eventChannel = new EventChannel(messenger, channelName  + "_event");
         eventChannel.setStreamHandler(flutterFibriListener);
+
+        graphView = createGraphView(context);
+        view = createView();
+
+        init();
+    }
+
+    private void init() {
+        setupSeries();
+    }
+
+    private void setupSeries() {
+        series.resetData(new DataPoint[0]);
+        series.setColor(Color.BLUE);
+        series.setThickness(8);
+        series.setBackgroundColor(Color.TRANSPARENT);
+        series.setDrawBackground(true);
+
+        int width = getScreenWidth(context);
+        boolean drawAsPath = width >= 1080;
+
+        series.setDrawAsPath(drawAsPath);
+    }
+
+    private void destroy() {
+        fibriChecker.stop();
+        methodChannel.setMethodCallHandler(null);
+        eventChannel.setStreamHandler(null);
+
+        valueSR.clear();
+        graphView.removeAllSeries();
+    }
+
+    private LinearLayout createView() {
+        LinearLayout linearLayout = new LinearLayout(context);
+        linearLayout.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT));
+        linearLayout.setOrientation(LinearLayout.HORIZONTAL);
+        linearLayout.addView(graphView);
+
+        fibriChecker = new FibriChecker.FibriBuilder(context, linearLayout).build();
+        fibriChecker.setFibriListener(flutterFibriListener);
+
+        return linearLayout;
     }
 
     @Override
     public View getView() {
-        return createView();
+        return view;
     }
 
     @Override
     public void dispose() {
-        fibriChecker.stop();
-        methodChannel.setMethodCallHandler(null);
-        eventChannel.setStreamHandler(null);
+        destroy();
     }
 
     //region Props Setters
@@ -140,7 +175,6 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
 
     public void setSampleTime(int sampleTime) {
         fibriChecker.sampleTime = sampleTime;
-        Log.i(TAG, "Sampletime set to: " + sampleTime);
     }
 
     public void setPulseDetectionExpiryTime(int pulseDetectionExpiryTime) {
@@ -280,32 +314,13 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
         }
     }
 
-    private LinearLayout createView() {
-
-        Log.i(TAG, "Creating View instance");
-
-        linearLayout = new LinearLayout(context);
-        linearLayout.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT));
-        linearLayout.setOrientation(LinearLayout.HORIZONTAL);
-
-        valueSR = new ArrayList<>();
-        graphView = createGraphView(context);
-
-        linearLayout.addView(graphView);
-
-        fibriChecker = new FibriChecker.FibriBuilder(context, linearLayout).build();
-        fibriChecker.setFibriListener(flutterFibriListener);
-
-        return linearLayout;
-    }
-
     //region Graphs
     private GraphView createGraphView(Context context) {
-        graphView = new GraphView(context);
-        invalidateGraphView(graphView, context);
+        final GraphView newGraphView = new GraphView(context);
+        invalidateGraphView(newGraphView, context);
+        newGraphView.addSeries(series);
 
-        Log.i(TAG, "W X H: " + graphView.getWidth() + " x " + graphView.getHeight());
-        return graphView;
+        return newGraphView;
     }
 
     private void invalidateGraphView(GraphView graphView, Context context) {
@@ -314,7 +329,6 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
         params.gravity = Gravity.CENTER_HORIZONTAL;
         graphView.setLayoutParams(params);
         setViewPortOptions(graphView);
-        setSeries(graphView, context);
     }
 
     private void setViewPortOptions(GraphView graphView) {
@@ -325,32 +339,6 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
         viewport.setYAxisBoundsManual(true);
         viewport.setMinX(0);
         viewport.setMaxX(SAMPLE_COUNT);
-    }
-
-    private void setSeries(GraphView graphView, Context context) {
-        ArrayList<DataPoint> dataPoints = new ArrayList<>();
-
-        // fill array wih empty values
-        DataPoint[] data = new DataPoint[SAMPLE_COUNT];
-        for (int i = 0; i < SAMPLE_COUNT; i++) {
-            data[i] = new DataPoint(0, 0);
-        }
-
-        this.series = new LineGraphSeries<DataPoint>(data);
-
-        series = new LineGraphSeries<>(dataPoints.toArray(new DataPoint[dataPoints.size()]));
-        series.setColor(Color.BLUE);
-        series.setThickness(8);
-        series.setBackgroundColor(Color.TRANSPARENT);
-        series.setDrawBackground(true);
-
-        int width = getScreenWidth(context);
-        boolean drawAsPath = width >= 1080;
-
-        series.setDrawAsPath(drawAsPath);
-
-        graphView.removeAllSeries();
-        graphView.addSeries(series);
     }
 
     private int getScreenWidth(Context context) {
@@ -390,7 +378,6 @@ public class FlutterFibriCheckView implements PlatformView, MethodChannel.Method
     }
 
     private void addValueToSR(double value) {
-
         valueSR.add(value);
         if (valueSR.size() > SAMPLE_COUNT) {
             valueSR.remove(0);

--- a/android/src/main/java/com/fibricheck/camera_sdk/FlutterFibriListener.java
+++ b/android/src/main/java/com/fibricheck/camera_sdk/FlutterFibriListener.java
@@ -35,7 +35,7 @@ public class FlutterFibriListener implements EventChannel.StreamHandler, IFibriL
     private static final String EVENT_MEASUREMENT_PROCESSED = "onMeasurementProcessed";
 
     private EventChannel.EventSink events;
-    private SampleReadyCallBack sampleReadyCallBack;
+    private final SampleReadyCallBack sampleReadyCallBack;
 
     FlutterFibriListener(SampleReadyCallBack sampleReadyCallBack) {
         this.sampleReadyCallBack = sampleReadyCallBack;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,15 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -21,12 +22,9 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
-
 android {
-    compileSdkVersion 33
+    namespace "com.fibricheck.camera_sdk_example"
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -39,8 +37,8 @@ android {
         applicationId "com.fibricheck.camera_sdk_example"
         // You can update the following values to match your application needs. 
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 20
-        targetSdkVersion 33
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0.1"
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.6.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.7.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
+}
+
+include ":app"

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
+    id "com.android.application" version "8.6.1" apply false
     id "org.jetbrains.kotlin.android" version "2.0.21" apply false
 }
 

--- a/example/lib/0_design_system/fc_colors.dart
+++ b/example/lib/0_design_system/fc_colors.dart
@@ -5,4 +5,5 @@ class FCColors {
   static const Color green = Color.fromARGB(255, 30, 141, 149);
   static const Color lightGray = Color.fromARGB(255, 211, 220, 228);
   static const Color darkGray = Color.fromARGB(255, 59, 69, 78);
+  static const Color bordeaux = Color.fromARGB(255, 95, 2, 31);
 }

--- a/example/lib/5_ui/widgets/fc_metrics.dart
+++ b/example/lib/5_ui/widgets/fc_metrics.dart
@@ -8,10 +8,10 @@ class DemoMetricsWidget extends StatefulWidget {
   final String heartBeat;
 
   const DemoMetricsWidget({
-    Key? key,
+    super.key,
     required this.timeRemaining,
     required this.heartBeat,
-  }) : super(key: key);
+  });
 
   @override
   State<DemoMetricsWidget> createState() => _DemoMetricsWidgetState();

--- a/example/lib/5_ui/widgets/fc_title.dart
+++ b/example/lib/5_ui/widgets/fc_title.dart
@@ -7,9 +7,9 @@ class DemoTitleWidget extends StatefulWidget {
   final String title;
 
   const DemoTitleWidget({
-    Key? key,
+    super.key,
     required this.title,
-  }) : super(key: key);
+  });
 
   @override
   State<DemoTitleWidget> createState() => _DemoTitleWidgetState();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'dart:async';
 
 import 'package:permission_handler/permission_handler.dart';
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'package:camera_sdk_example/0_design_system/fc_colors.dart';
 import 'package:camera_sdk_example/5_ui/widgets/fc_title.dart';
@@ -82,7 +82,7 @@ class _MyAppState extends State<MyApp> {
                             }),
                           },
                           onFingerDetected: () => {
-                            Wakelock.enable(),
+                            WakelockPlus.enable(),
                             debugPrint("Flutter onFingerDetected"),
                             setState(() {
                               _status = "Detecting pulse...";
@@ -90,7 +90,7 @@ class _MyAppState extends State<MyApp> {
                           },
                           onFingerDetectionTimeExpired: () => debugPrint("Flutter onFingerDetectionTimeExpired"),
                           onFingerRemoved: (y, v, stdDevY) => {
-                            Wakelock.disable(),
+                            WakelockPlus.disable(),
                             debugPrint("Flutter onFingerRemoved $y, $v, $stdDevY"),
                           },
                           onHeartBeat: (heartbeat) => {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,8 +9,8 @@ import 'package:camera_sdk_example/0_design_system/fc_colors.dart';
 import 'package:camera_sdk_example/5_ui/widgets/fc_title.dart';
 import 'package:camera_sdk_example/5_ui/widgets/fc_metrics.dart';
 
-class FirstRoute extends StatelessWidget {
-  const FirstRoute({super.key});
+class StartScreen extends StatelessWidget {
+  const StartScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +38,7 @@ void main() {
 
   runApp(const MaterialApp(
     title: 'Fibricheck Example',
-    home: FirstRoute(),
+    home: StartScreen(),
   ));
 }
 
@@ -100,7 +100,20 @@ class _MyAppState extends State<MyApp> {
                   child: FibriCheckView(
                     fibriCheckViewProperties: FibriCheckViewProperties(
                       flashEnabled: true,
-                      lineThickness: 4,
+                      lineThickness: 2,
+                      // graphBackgroundColor: '#${FCColors.green.value.toRadixString(16)}'
+                      drawGraph: true,
+                      lineColor: '#${FCColors.bordeaux.value.toRadixString(16)}',
+                      drawBackground: true,
+                      sampleTime: 15,
+                      gravEnabled: false,
+                      gyroEnabled: false,
+                      accEnabled: false,
+                      rotationEnabled: false,
+                      movementDetectionEnabled: true,
+                      fingerDetectionExpiryTime: -1,
+                      pulseDetectionExpiryTime: 10,
+                      waitForStartRecordingSignal:  false
                     ),
                     onCalibrationReady: () => {
                       debugPrint("Flutter onCalibrationReady"),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -67,118 +67,121 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Measurement'),
-      ),
-      body: Column(children: [
-      Expanded(
-        child: FutureBuilder(
-          future: _requestCameraPermission,
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const DemoTitleWidget(
-                  title: "Requiring camera permission");
-            }
-
-            if (!_hasCameraPermission) {
-              return const DemoTitleWidget(
-                  title: "Camera permission not granted");
-            }
-            return Column(
-              children: [
-                DemoTitleWidget(title: _status),
-                Container(
-                  decoration: const BoxDecoration(
-                    border: Border(
-                      top: BorderSide(color: FCColors.lightGray, width: 1),
-                      bottom: BorderSide(color: FCColors.lightGray, width: 1),
-                    ),
-                  ),
-                  height: 200,
-                  child: FibriCheckView(
-                    fibriCheckViewProperties: FibriCheckViewProperties(
-                      flashEnabled: true,
-                      lineThickness: 2,
-                      // graphBackgroundColor: '#${FCColors.green.value.toRadixString(16)}'
-                      drawGraph: true,
-                      lineColor: '#${FCColors.bordeaux.value.toRadixString(16)}',
-                      drawBackground: true,
-                      sampleTime: 15,
-                      gravEnabled: false,
-                      gyroEnabled: false,
-                      accEnabled: false,
-                      rotationEnabled: false,
-                      movementDetectionEnabled: true,
-                      fingerDetectionExpiryTime: -1,
-                      pulseDetectionExpiryTime: 10,
-                      waitForStartRecordingSignal:  false
-                    ),
-                    onCalibrationReady: () => {
-                      debugPrint("Flutter onCalibrationReady"),
-                      setState(() {
-                        _status = "Recording heartbeat...";
-                      }),
-                    },
-                    onFingerDetected: () => {
-                      WakelockPlus.enable(),
-                      debugPrint("Flutter onFingerDetected"),
-                      setState(() {
-                        _status = "Detecting pulse...";
-                      }),
-                    },
-                    onFingerDetectionTimeExpired: () =>
-                        debugPrint("Flutter onFingerDetectionTimeExpired"),
-                    onFingerRemoved: (y, v, stdDevY) => {
-                      WakelockPlus.disable(),
-                      debugPrint("Flutter onFingerRemoved $y, $v, $stdDevY"),
-                    },
-                    onHeartBeat: (heartbeat) => {
-                      debugPrint("Flutter onHeartBeat $heartbeat"),
-                      setState(() {
-                        _heartBeat = heartbeat.toString();
-                      }),
-                    },
-                    onMeasurementFinished: () => {
-                      debugPrint("Flutter onMeasurementFinished"),
-                      setState(() {
-                        _status = "Measurement finished!";
-                      }),
-                    },
-                    onMeasurementProcessed: (measurement) => {
-                      debugPrint("Flutter onMeasurementProcessed $measurement"),
-                    },
-                    onMeasurementStart: () =>
-                        debugPrint("Flutter onMeasurementStart"),
-                    onMovementDetected: () =>
-                        debugPrint("Flutter onMovementDetected"),
-                    onPulseDetected: () => {
-                      debugPrint("Flutter onPulseDetected"),
-                      setState(() {
-                        _status = "Calibrating...";
-                      }),
-                    },
-                    onPulseDetectionTimeExpired: () =>
-                        debugPrint("Flutter onPulseDetectionTimeExpired"),
-                    onSampleReady: (ppg, raw) => {},
-                    //debugPrint("Flutter onSampleReady $ppg $raw"), -> prints often. Only uncomment when data is relevant
-                    onTimeRemaining: (seconds) => {
-                      debugPrint("Flutter onTimeRemaining $seconds"),
-                      setState(() {
-                        _timeRemaining = seconds.toString();
-                      }),
-                    },
-                    onMeasurementError: (message) =>
-                        debugPrint("Flutter onMeasurementError: $message"),
-                  ),
-                ),
-                DemoMetricsWidget(
-                    timeRemaining: _timeRemaining, heartBeat: _heartBeat),
-              ],
-            );
-          },
+        appBar: AppBar(
+          title: const Text('Measurement'),
         ),
-      ),
-    ]));
+        body: Column(children: [
+          Expanded(
+            child: FutureBuilder(
+              future: _requestCameraPermission,
+              builder: (context, snapshot) {
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const DemoTitleWidget(
+                      title: "Requiring camera permission");
+                }
+
+                if (!_hasCameraPermission) {
+                  return const DemoTitleWidget(
+                      title: "Camera permission not granted");
+                }
+                return Column(
+                  children: [
+                    DemoTitleWidget(title: _status),
+                    Container(
+                      decoration: const BoxDecoration(
+                        border: Border(
+                          top: BorderSide(color: FCColors.lightGray, width: 1),
+                          bottom:
+                              BorderSide(color: FCColors.lightGray, width: 1),
+                        ),
+                      ),
+                      height: 200,
+                      child: FibriCheckView(
+                        fibriCheckViewProperties: FibriCheckViewProperties(
+                            flashEnabled: true,
+                            lineThickness: 2,
+                            // graphBackgroundColor: '#${FCColors.green.value.toRadixString(16)}'
+                            drawGraph: true,
+                            lineColor:
+                                '#${FCColors.bordeaux.value.toRadixString(16)}',
+                            drawBackground: true,
+                            sampleTime: 15,
+                            gravEnabled: false,
+                            gyroEnabled: false,
+                            accEnabled: false,
+                            rotationEnabled: false,
+                            movementDetectionEnabled: true,
+                            fingerDetectionExpiryTime: -1,
+                            pulseDetectionExpiryTime: 10,
+                            waitForStartRecordingSignal: false),
+                        onCalibrationReady: () => {
+                          debugPrint("Flutter onCalibrationReady"),
+                          setState(() {
+                            _status = "Recording heartbeat...";
+                          }),
+                        },
+                        onFingerDetected: () => {
+                          WakelockPlus.enable(),
+                          debugPrint("Flutter onFingerDetected"),
+                          setState(() {
+                            _status = "Detecting pulse...";
+                          }),
+                        },
+                        onFingerDetectionTimeExpired: () =>
+                            debugPrint("Flutter onFingerDetectionTimeExpired"),
+                        onFingerRemoved: (y, v, stdDevY) => {
+                          WakelockPlus.disable(),
+                          debugPrint(
+                              "Flutter onFingerRemoved $y, $v, $stdDevY"),
+                        },
+                        onHeartBeat: (heartbeat) => {
+                          debugPrint("Flutter onHeartBeat $heartbeat"),
+                          setState(() {
+                            _heartBeat = heartbeat.toString();
+                          }),
+                        },
+                        onMeasurementFinished: () => {
+                          debugPrint("Flutter onMeasurementFinished"),
+                          setState(() {
+                            _status = "Measurement finished!";
+                          }),
+                        },
+                        onMeasurementProcessed: (measurement) => {
+                          debugPrint(
+                              "Flutter onMeasurementProcessed $measurement"),
+                        },
+                        onMeasurementStart: () =>
+                            debugPrint("Flutter onMeasurementStart"),
+                        onMovementDetected: () =>
+                            debugPrint("Flutter onMovementDetected"),
+                        onPulseDetected: () => {
+                          debugPrint("Flutter onPulseDetected"),
+                          setState(() {
+                            _status = "Calibrating...";
+                          }),
+                        },
+                        onPulseDetectionTimeExpired: () =>
+                            debugPrint("Flutter onPulseDetectionTimeExpired"),
+                        onSampleReady: (ppg, raw) => {},
+                        //debugPrint("Flutter onSampleReady $ppg $raw"), -> prints often. Only uncomment when data is relevant
+                        onTimeRemaining: (seconds) => {
+                          debugPrint("Flutter onTimeRemaining $seconds"),
+                          setState(() {
+                            _timeRemaining = seconds.toString();
+                          }),
+                        },
+                        onMeasurementError: (message) =>
+                            debugPrint("Flutter onMeasurementError: $message"),
+                      ),
+                    ),
+                    DemoMetricsWidget(
+                        timeRemaining: _timeRemaining, heartBeat: _heartBeat),
+                  ],
+                );
+              },
+            ),
+          ),
+        ]));
   }
 
   Future<void> _requestCameraPermissionImpl() async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,10 +9,37 @@ import 'package:camera_sdk_example/0_design_system/fc_colors.dart';
 import 'package:camera_sdk_example/5_ui/widgets/fc_title.dart';
 import 'package:camera_sdk_example/5_ui/widgets/fc_metrics.dart';
 
+class FirstRoute extends StatelessWidget {
+  const FirstRoute({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Home'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          child: const Text('Start Measurement'),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => const MyApp()),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
 
-  runApp(const MyApp());
+  runApp(const MaterialApp(
+    title: 'Fibricheck Example',
+    home: FirstRoute(),
+  ));
 }
 
 class MyApp extends StatefulWidget {
@@ -39,105 +66,106 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        backgroundColor: FCColors.brokenWhite,
-        appBar: AppBar(
-          backgroundColor: FCColors.green,
-          title: const Text("Fibricheck example app"),
-        ),
-        body: Column(
-          children: [
-            Expanded(
-              child: FutureBuilder(
-                future: _requestCameraPermission,
-                builder: (context, snapshot) {
-                  if (snapshot.connectionState == ConnectionState.waiting) {
-                    return const DemoTitleWidget(title: "Requiring camera permission");
-                  }
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Measurement'),
+      ),
+      body: Column(children: [
+      Expanded(
+        child: FutureBuilder(
+          future: _requestCameraPermission,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const DemoTitleWidget(
+                  title: "Requiring camera permission");
+            }
 
-                  if (!_hasCameraPermission) {
-                    return const DemoTitleWidget(title: "Camera permission not granted");
-                  }
-                  return Column(
-                    children: [
-                      DemoTitleWidget(title: _status),
-                      Container(
-                        decoration: const BoxDecoration(
-                          border: Border(
-                            top: BorderSide(color: FCColors.lightGray, width: 1),
-                            bottom: BorderSide(color: FCColors.lightGray, width: 1),
-                          ),
-                        ),
-                        height: 200,
-                        child: FibriCheckView(
-                          fibriCheckViewProperties: FibriCheckViewProperties(
-                            flashEnabled: true,
-                            lineThickness: 4,
-                          ),
-                          onCalibrationReady: () => {
-                            debugPrint("Flutter onCalibrationReady"),
-                            setState(() {
-                              _status = "Recording heartbeat...";
-                            }),
-                          },
-                          onFingerDetected: () => {
-                            WakelockPlus.enable(),
-                            debugPrint("Flutter onFingerDetected"),
-                            setState(() {
-                              _status = "Detecting pulse...";
-                            }),
-                          },
-                          onFingerDetectionTimeExpired: () => debugPrint("Flutter onFingerDetectionTimeExpired"),
-                          onFingerRemoved: (y, v, stdDevY) => {
-                            WakelockPlus.disable(),
-                            debugPrint("Flutter onFingerRemoved $y, $v, $stdDevY"),
-                          },
-                          onHeartBeat: (heartbeat) => {
-                            debugPrint("Flutter onHeartBeat $heartbeat"),
-                            setState(() {
-                              _heartBeat = heartbeat.toString();
-                            }),
-                          },
-                          onMeasurementFinished: () => {
-                            debugPrint("Flutter onMeasurementFinished"),
-                            setState(() {
-                              _status = "Measurement finished!";
-                            }),
-                          },
-                          onMeasurementProcessed: (measurement) => {
-                            debugPrint("Flutter onMeasurementProcessed $measurement"),
-                          },
-                          onMeasurementStart: () => debugPrint("Flutter onMeasurementStart"),
-                          onMovementDetected: () => debugPrint("Flutter onMovementDetected"),
-                          onPulseDetected: () => {
-                            debugPrint("Flutter onPulseDetected"),
-                            setState(() {
-                              _status = "Calibrating...";
-                            }),
-                          },
-                          onPulseDetectionTimeExpired: () => debugPrint("Flutter onPulseDetectionTimeExpired"),
-                          onSampleReady: (ppg, raw) => {},
-                          //debugPrint("Flutter onSampleReady $ppg $raw"), -> prints often. Only uncomment when data is relevant
-                          onTimeRemaining: (seconds) => {
-                            debugPrint("Flutter onTimeRemaining $seconds"),
-                            setState(() {
-                              _timeRemaining = seconds.toString();
-                            }),
-                          },
-                          onMeasurementError: (message) => debugPrint("Flutter onMeasurementError: $message"),
-                        ),
-                      ),
-                      DemoMetricsWidget(timeRemaining: _timeRemaining, heartBeat: _heartBeat),
-                    ],
-                  );
-                },
-              ),
-            ),
-          ],
+            if (!_hasCameraPermission) {
+              return const DemoTitleWidget(
+                  title: "Camera permission not granted");
+            }
+            return Column(
+              children: [
+                DemoTitleWidget(title: _status),
+                Container(
+                  decoration: const BoxDecoration(
+                    border: Border(
+                      top: BorderSide(color: FCColors.lightGray, width: 1),
+                      bottom: BorderSide(color: FCColors.lightGray, width: 1),
+                    ),
+                  ),
+                  height: 200,
+                  child: FibriCheckView(
+                    fibriCheckViewProperties: FibriCheckViewProperties(
+                      flashEnabled: true,
+                      lineThickness: 4,
+                    ),
+                    onCalibrationReady: () => {
+                      debugPrint("Flutter onCalibrationReady"),
+                      setState(() {
+                        _status = "Recording heartbeat...";
+                      }),
+                    },
+                    onFingerDetected: () => {
+                      WakelockPlus.enable(),
+                      debugPrint("Flutter onFingerDetected"),
+                      setState(() {
+                        _status = "Detecting pulse...";
+                      }),
+                    },
+                    onFingerDetectionTimeExpired: () =>
+                        debugPrint("Flutter onFingerDetectionTimeExpired"),
+                    onFingerRemoved: (y, v, stdDevY) => {
+                      WakelockPlus.disable(),
+                      debugPrint("Flutter onFingerRemoved $y, $v, $stdDevY"),
+                    },
+                    onHeartBeat: (heartbeat) => {
+                      debugPrint("Flutter onHeartBeat $heartbeat"),
+                      setState(() {
+                        _heartBeat = heartbeat.toString();
+                      }),
+                    },
+                    onMeasurementFinished: () => {
+                      debugPrint("Flutter onMeasurementFinished"),
+                      setState(() {
+                        _status = "Measurement finished!";
+                      }),
+                    },
+                    onMeasurementProcessed: (measurement) => {
+                      debugPrint("Flutter onMeasurementProcessed $measurement"),
+                    },
+                    onMeasurementStart: () =>
+                        debugPrint("Flutter onMeasurementStart"),
+                    onMovementDetected: () =>
+                        debugPrint("Flutter onMovementDetected"),
+                    onPulseDetected: () => {
+                      debugPrint("Flutter onPulseDetected"),
+                      setState(() {
+                        _status = "Calibrating...";
+                      }),
+                    },
+                    onPulseDetectionTimeExpired: () =>
+                        debugPrint("Flutter onPulseDetectionTimeExpired"),
+                    onSampleReady: (ppg, raw) => {},
+                    //debugPrint("Flutter onSampleReady $ppg $raw"), -> prints often. Only uncomment when data is relevant
+                    onTimeRemaining: (seconds) => {
+                      debugPrint("Flutter onTimeRemaining $seconds"),
+                      setState(() {
+                        _timeRemaining = seconds.toString();
+                      }),
+                    },
+                    onMeasurementError: (message) =>
+                        debugPrint("Flutter onMeasurementError: $message"),
+                  ),
+                ),
+                DemoMetricsWidget(
+                    timeRemaining: _timeRemaining, heartBeat: _heartBeat),
+              ],
+            );
+          },
         ),
       ),
-    );
+    ]));
   }
 
   Future<void> _requestCameraPermissionImpl() async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,6 +58,8 @@ class _MyAppState extends State<MyApp> {
   String _heartBeat = "-";
   String _status = "Place your finger on the camera";
 
+  late FibriCheckViewMethodController _controller;
+
   @override
   initState() {
     super.initState();
@@ -156,8 +158,13 @@ class _MyAppState extends State<MyApp> {
                     },
                     onMeasurementError: (message) =>
                         debugPrint("Flutter onMeasurementError: $message"),
+                    onControllerCreated: (viewController) => {
+                      _controller = viewController
+                    },
                   ),
                 ),
+                TextButton(onPressed: onStopPressed, child: Text("Stop")),
+                TextButton(onPressed: onStartPressed, child: Text("Resume")),
                 DemoMetricsWidget(
                     timeRemaining: _timeRemaining, heartBeat: _heartBeat),
               ],
@@ -166,6 +173,14 @@ class _MyAppState extends State<MyApp> {
         ),
       ),
     ]));
+  }
+
+  Future<void> onStopPressed() async {
+    _controller.resetModule();
+  }
+
+  Future<void> onStartPressed() async {
+    _controller.allPropertiesInitialized();
   }
 
   Future<void> _requestCameraPermissionImpl() async {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -58,8 +58,6 @@ class _MyAppState extends State<MyApp> {
   String _heartBeat = "-";
   String _status = "Place your finger on the camera";
 
-  late FibriCheckViewMethodController _controller;
-
   @override
   initState() {
     super.initState();
@@ -171,13 +169,8 @@ class _MyAppState extends State<MyApp> {
                     },
                     onMeasurementError: (message) =>
                         debugPrint("Flutter onMeasurementError: $message"),
-                    onControllerCreated: (viewController) => {
-                      _controller = viewController
-                    },
                   ),
                 ),
-                TextButton(onPressed: onStopPressed, child: Text("Stop")),
-                TextButton(onPressed: onStartPressed, child: Text("Resume")),
                 DemoMetricsWidget(
                     timeRemaining: _timeRemaining, heartBeat: _heartBeat),
               ],
@@ -186,14 +179,6 @@ class _MyAppState extends State<MyApp> {
         ),
       ),
     ]));
-  }
-
-  Future<void> onStopPressed() async {
-    _controller.resetModule();
-  }
-
-  Future<void> onStartPressed() async {
-    _controller.allPropertiesInitialized();
   }
 
   Future<void> _requestCameraPermissionImpl() async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler: ^10.0.0
+  permission_handler: ^11.3.1
   
   camera_sdk:
     # When depending on this package from a real application you should use:
@@ -30,7 +30,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  wakelock: ^0.6.2
+  wakelock_plus: ^1.2.8
 
 dev_dependencies:
   flutter_test:
@@ -42,7 +42,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/src/fibricheck_view.dart
+++ b/lib/src/fibricheck_view.dart
@@ -31,7 +31,7 @@ class FibriCheckView extends StatefulWidget {
   late final Function(String message) onMeasurementError;
 
   FibriCheckView({
-    Key? key,
+    super.key,
     FibriCheckViewProperties? fibriCheckViewProperties,
     Function? onFingerDetected,
     Function(double y, double v, double stdDevY)? onFingerRemoved,
@@ -47,7 +47,7 @@ class FibriCheckView extends StatefulWidget {
     Function? onMovementDetected,
     Function(Map<String, dynamic> measurement)? onMeasurementProcessed,
     Function(String message)? onMeasurementError,
-  }) : super(key: key) {
+  }) {
     _fibriCheckViewProperties =
         fibriCheckViewProperties ?? FibriCheckViewProperties();
 
@@ -174,6 +174,7 @@ class FibriCheckViewState extends State<FibriCheckView>
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       _fibriCheckViewMethodController!.resetModule();
+    
     }
 
     super.dispose();
@@ -189,6 +190,7 @@ class FibriCheckViewState extends State<FibriCheckView>
   @override
   Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
     switch (state) {
+      case AppLifecycleState.hidden:
       case AppLifecycleState.detached:
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:

--- a/lib/src/fibricheck_view.dart
+++ b/lib/src/fibricheck_view.dart
@@ -222,8 +222,6 @@ class FibriCheckViewState extends State<FibriCheckView>
 
     _fibriCheckViewEventController.subscribe();
     _fibriCheckViewMethodController.allPropertiesInitialized();
-
-    // widget.onControllerCreated(_fibriCheckViewMethodController);
   }
 
   Future<void> _setupProperties() async {

--- a/lib/src/fibricheck_view.dart
+++ b/lib/src/fibricheck_view.dart
@@ -5,10 +5,8 @@ import 'package:uuid/uuid.dart';
 
 import 'fibricheck_view_event_controller.dart';
 import 'fibricheck_view_method_controller.dart';
-// export 'fibricheck_view_method_controller.dart';
 import 'fibricheck_view_properties.dart';
 export 'fibricheck_view_properties.dart';
-
 
 class MeasurementErrors {
   static const String brokenAccSensorError = "BROKEN_ACC_SENSOR";
@@ -32,8 +30,6 @@ class FibriCheckView extends StatefulWidget {
       onMeasurementProcessed;
   late final Function(String message) onMeasurementError;
 
-  // final Function(FibriCheckViewMethodController) onControllerCreated;
-
   FibriCheckView({
     super.key,
     FibriCheckViewProperties? fibriCheckViewProperties,
@@ -51,7 +47,6 @@ class FibriCheckView extends StatefulWidget {
     Function? onMovementDetected,
     Function(Map<String, dynamic> measurement)? onMeasurementProcessed,
     Function(String message)? onMeasurementError,
-    // required this.onControllerCreated
   }) {
     _fibriCheckViewProperties =
         fibriCheckViewProperties ?? FibriCheckViewProperties();
@@ -179,7 +174,6 @@ class FibriCheckViewState extends State<FibriCheckView>
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
       _fibriCheckViewMethodController.resetModule();
-    
     }
 
     super.dispose();

--- a/lib/src/fibricheck_view.dart
+++ b/lib/src/fibricheck_view.dart
@@ -5,7 +5,7 @@ import 'package:uuid/uuid.dart';
 
 import 'fibricheck_view_event_controller.dart';
 import 'fibricheck_view_method_controller.dart';
-export 'fibricheck_view_method_controller.dart';
+// export 'fibricheck_view_method_controller.dart';
 import 'fibricheck_view_properties.dart';
 export 'fibricheck_view_properties.dart';
 
@@ -32,7 +32,7 @@ class FibriCheckView extends StatefulWidget {
       onMeasurementProcessed;
   late final Function(String message) onMeasurementError;
 
-  final Function(FibriCheckViewMethodController) onControllerCreated;
+  // final Function(FibriCheckViewMethodController) onControllerCreated;
 
   FibriCheckView({
     super.key,
@@ -51,7 +51,7 @@ class FibriCheckView extends StatefulWidget {
     Function? onMovementDetected,
     Function(Map<String, dynamic> measurement)? onMeasurementProcessed,
     Function(String message)? onMeasurementError,
-    required this.onControllerCreated
+    // required this.onControllerCreated
   }) {
     _fibriCheckViewProperties =
         fibriCheckViewProperties ?? FibriCheckViewProperties();
@@ -229,7 +229,7 @@ class FibriCheckViewState extends State<FibriCheckView>
     _fibriCheckViewEventController.subscribe();
     _fibriCheckViewMethodController.allPropertiesInitialized();
 
-    widget.onControllerCreated(_fibriCheckViewMethodController);
+    // widget.onControllerCreated(_fibriCheckViewMethodController);
   }
 
   Future<void> _setupProperties() async {

--- a/lib/src/fibricheck_view.dart
+++ b/lib/src/fibricheck_view.dart
@@ -5,8 +5,10 @@ import 'package:uuid/uuid.dart';
 
 import 'fibricheck_view_event_controller.dart';
 import 'fibricheck_view_method_controller.dart';
+export 'fibricheck_view_method_controller.dart';
 import 'fibricheck_view_properties.dart';
 export 'fibricheck_view_properties.dart';
+
 
 class MeasurementErrors {
   static const String brokenAccSensorError = "BROKEN_ACC_SENSOR";
@@ -30,6 +32,8 @@ class FibriCheckView extends StatefulWidget {
       onMeasurementProcessed;
   late final Function(String message) onMeasurementError;
 
+  final Function(FibriCheckViewMethodController) onControllerCreated;
+
   FibriCheckView({
     super.key,
     FibriCheckViewProperties? fibriCheckViewProperties,
@@ -47,6 +51,7 @@ class FibriCheckView extends StatefulWidget {
     Function? onMovementDetected,
     Function(Map<String, dynamic> measurement)? onMeasurementProcessed,
     Function(String message)? onMeasurementError,
+    required this.onControllerCreated
   }) {
     _fibriCheckViewProperties =
         fibriCheckViewProperties ?? FibriCheckViewProperties();
@@ -124,8 +129,8 @@ class FibriCheckViewState extends State<FibriCheckView>
   String _channelId = "";
   final Map<String, dynamic> _creationParams = <String, dynamic>{};
 
-  FibriCheckViewEventController? _fibriCheckViewEventController;
-  FibriCheckViewMethodController? _fibriCheckViewMethodController;
+  late FibriCheckViewEventController _fibriCheckViewEventController;
+  late FibriCheckViewMethodController _fibriCheckViewMethodController;
 
   @override
   void initState() {
@@ -173,7 +178,7 @@ class FibriCheckViewState extends State<FibriCheckView>
     WidgetsBinding.instance.removeObserver(this);
 
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      _fibriCheckViewMethodController!.resetModule();
+      _fibriCheckViewMethodController.resetModule();
     
     }
 
@@ -182,7 +187,7 @@ class FibriCheckViewState extends State<FibriCheckView>
 
   Future<void> _stopNativeSideAndResetTheChannel() async {
     // Let's be sure that the FibriChecker is stopped !
-    await _fibriCheckViewMethodController?.resetModule();
+    await _fibriCheckViewMethodController.resetModule();
 
     _setupChannelId();
   }
@@ -221,16 +226,14 @@ class FibriCheckViewState extends State<FibriCheckView>
 
     await _setupProperties();
 
-    _fibriCheckViewEventController!.subscribe();
-    _fibriCheckViewMethodController!.allPropertiesInitialized();
+    _fibriCheckViewEventController.subscribe();
+    _fibriCheckViewMethodController.allPropertiesInitialized();
+
+    widget.onControllerCreated(_fibriCheckViewMethodController);
   }
 
   Future<void> _setupProperties() async {
     final methodController = _fibriCheckViewMethodController;
-
-    if (methodController == null) {
-      return;
-    }
 
     await methodController.setGraphBackgroundColor(graphBackgroundColor);
     await methodController.setDrawGraph(drawGraph);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,12 +13,12 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
-  uuid: ^3.0.6
+  uuid: ^4.5.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
[Link to ticket](https://qompium.atlassian.net/browse/FCS-67?atlOrigin=eyJpIjoiZjM0NDRmNzE0YTIzNGYzZDgzMDNmMDUwZGU5MDVhZWUiLCJwIjoiaiJ9)

### Reported bug
A customer reported that on android the flash and measurement would remain active even when the view was dismissed/disposed.

### The issue
On android, the `getView` function always created a new instance of the `FibriChecker` without dismissing the previous one. Whenever the FibriCheckView was disposed, it would call `getView` twice in succession, followed by the `dispose` call. This `getView` then created 2 new `FibriChecker` instances. This either caused a race condition where the `dispose` disabled the `FibriChecker`, and the `createView` enabled it again. Or the `FibriChecker` had multiple instances running and only one of them got disabled. 

### The fix
To fix the bug, I made it so that only one instance of the view is created when the view is created and afterward it gets returned by `getView`. I also refactored the initialization flow a little bit so that fewer things are unnecessarily recreated and more things are reused when possible. 